### PR TITLE
Fix: Fastqc renaming bug

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -25,58 +25,56 @@ import yaml
 sample_sheet = config["sample_sheet"]
 SAMPLES = {}
 with open(sample_sheet) as sample_sheet_file:
-    SAMPLES = yaml.safe_load(sample_sheet_file) 
+    SAMPLES = yaml.safe_load(sample_sheet_file)
 
 OUT = config["out"]
 IN = config["input_dir"]
 
-#@################################################################################
-#@#### 				Processes                                    #####
-#@################################################################################
+# @################################################################################
+# @#### 				Processes                                    #####
+# @################################################################################
 
-    #############################################################################
-    ##### Data quality control and cleaning                                 #####
-    #############################################################################
+
+#############################################################################
+##### Data quality control and cleaning                                 #####
+#############################################################################
 include: "bin/rules/fastqc_raw_data.smk"
 include: "bin/rules/clean_fastq.smk"
 include: "bin/rules/fastqc_clean_data.smk"
-
-    #############################################################################
-    ##### De novo assembly                                                  #####
-    #############################################################################
+#############################################################################
+##### De novo assembly                                                  #####
+#############################################################################
 include: "bin/rules/de_novo_assembly.smk"
-
-    #############################################################################
-    ##### Species identification                                            #####
-    #############################################################################
+#############################################################################
+##### Species identification                                            #####
+#############################################################################
 include: "bin/rules/identify_species.smk"
-
-    #############################################################################
-    ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
-    #############################################################################
+#############################################################################
+##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
+#############################################################################
 include: "bin/rules/run_quast.smk"
-
 include: "bin/rules/run_checkm.smk"
 include: "bin/rules/parse_checkm.smk"
-
 include: "bin/rules/picard_insert_size.smk"
 include: "bin/rules/generate_contig_metrics.smk"
 include: "bin/rules/parse_bbtools.smk"
 include: "bin/rules/parse_bbtools_summary.smk"
-
 include: "bin/rules/multiqc.smk"
 
 
-#@################################################################################
-#@#### The `onstart` checker codeblock                                       #####
-#@################################################################################
+# @################################################################################
+# @#### The `onstart` checker codeblock                                       #####
+# @################################################################################
+
 
 onstart:
     print("Checking if all specified files are accessible...")
-    important_files = [ config["sample_sheet"],
-                    'files/trimmomatic_0.36_adapters_lists/NexteraPE-PE.fa',
-                    'files/accepted_genera_checkm.txt',
-                    'files/multiqc_config.yaml' ]
+    important_files = [
+        config["sample_sheet"],
+        "files/trimmomatic_0.36_adapters_lists/NexteraPE-PE.fa",
+        "files/accepted_genera_checkm.txt",
+        "files/multiqc_config.yaml",
+    ]
     for filename in important_files:
         if not os.path.exists(filename):
             raise FileNotFoundError(filename)
@@ -86,22 +84,49 @@ onstart:
 ##### Specify final output:                                                 #####
 #################################################################################
 
+
 localrules:
-    all
+    all,
 
 
 rule all:
     input:
-        expand(OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.zip", sample = SAMPLES, read = ['R1', 'R2']),   
-        expand(OUT + "/clean_fastq/{sample}_{read}.fastq.gz", sample = SAMPLES, read = ['pR1', 'pR2']),
-        expand(OUT + "/qc_clean_fastq/{sample}_{read}_fastqc.zip", sample = SAMPLES, read = ['pR1', 'pR2']),
-        expand(OUT + "/de_novo_assembly/{sample}/scaffolds.fasta", sample = SAMPLES),
-        expand(OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}/checkm_{sample}.tsv", sample = SAMPLES),   
+        expand(
+            OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.zip",
+            sample=SAMPLES,
+            read=["R1", "R2"],
+        ),
+        expand(
+            OUT + "/clean_fastq/{sample}_{read}.fastq.gz",
+            sample=SAMPLES,
+            read=["pR1", "pR2"],
+        ),
+        expand(
+            OUT + "/qc_clean_fastq/{sample}_{read}_fastqc.zip",
+            sample=SAMPLES,
+            read=["pR1", "pR2"],
+        ),
+        expand(OUT + "/de_novo_assembly/{sample}/scaffolds.fasta", sample=SAMPLES),
+        expand(
+            OUT
+            + "/qc_de_novo_assembly/checkm/per_sample/{sample}/checkm_{sample}.tsv",
+            sample=SAMPLES,
+        ),
         OUT + "/qc_de_novo_assembly/quast/report.tsv",
-        expand(OUT + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_MinLenFiltSummary.tsv", sample = SAMPLES),
+        expand(
+            OUT
+            + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_MinLenFiltSummary.tsv",
+            sample=SAMPLES,
+        ),
         OUT + "/qc_de_novo_assembly/bbtools_scaffolds/bbtools_scaffolds.tsv",
         OUT + "/qc_de_novo_assembly/bbtools_scaffolds/bbtools_summary_report.tsv",
-        expand(OUT + '/identify_species/{sample}/{sample}_species_content.txt', sample = SAMPLES),
-        expand(OUT + '/identify_species/{sample}/{sample}_bracken_species.kreport2', sample = SAMPLES),
-        OUT + '/identify_species/top1_species_multireport.csv',
-        OUT + "/multiqc/multiqc.html"
+        expand(
+            OUT + "/identify_species/{sample}/{sample}_species_content.txt",
+            sample=SAMPLES,
+        ),
+        expand(
+            OUT + "/identify_species/{sample}/{sample}_bracken_species.kreport2",
+            sample=SAMPLES,
+        ),
+        OUT + "/identify_species/top1_species_multireport.csv",
+        OUT + "/multiqc/multiqc.html",

--- a/bin/fastqc_wrapper.sh
+++ b/bin/fastqc_wrapper.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#####################################################################################################################
+### This is a wrapper for fastqc used in the snakefile.                                                           
+###
+###     Usage: bin/fastqc_wrapper.sh {input} {params.output_dir} {output.html} 
+{output.zip} {log}                 ###
+###     Reason: Fastqc implicitly generates output files based on the input file name. 
+Therefore, if these are    ###
+###             not the same, this output is moved to the explicitly Snakefile defined 
+output location.           ###
+###     I had to put this simple bash code into a script because of the Snakemake-bash 
+strict settings, see:      ###
+### 
+https://snakemake.readthedocs.io/en/stable/project_info/faq.html#my-shell-command-fails-with-with-errors-about-an-unbound-variable-what-s-wrong
+#####################################################################################################################
+
+# Import the positional arguments (specified in the Snakefile)
+INPUT_FILE="$1"
+OUTPUT_DIR="$2"
+DESIRED_OUTPUT_HTML="$3"
+DESIRED_OUTPUT_ZIP="$4"
+LOG="$5"
+
+# Generate sample basename (i.e. remove everything before the last '/' and then remove 
+everything after the '.')
+EXTENSION1=".gz"
+EXTENSION2=".fastq"
+EXTENSION3=".fq"
+
+
+SAMPLE_TEMP="${INPUT_FILE##*/}"
+TEMP1=${SAMPLE_TEMP//$EXTENSION1/}
+TEMP2=${TEMP1//$EXTENSION2/}
+TEMP3=${TEMP2//$EXTENSION3/}
+
+SAMPLE_NAME="${TEMP3}"
+
+# These are the output files that fastqc implicitly generates (based on the input file 
+basename)
+REAL_OUTPUT_HTML="${OUTPUT_DIR}${SAMPLE_NAME}_fastqc.html"
+REAL_OUTPUT_ZIP="${OUTPUT_DIR}${SAMPLE_NAME}_fastqc.zip"
+
+# Run fastqc
+fastqc --outdir ${OUTPUT_DIR} ${INPUT_FILE} > ${LOG} 2>&1
+
+# If the implicit output file are not equal to the explicitly defined output in the 
+Snakefile, rename them to the explicitly defined output name.
+if [ "$DESIRED_OUTPUT_HTML" != "$REAL_OUTPUT_HTML" ]
+then
+    mv $REAL_OUTPUT_HTML $DESIRED_OUTPUT_HTML
+fi
+
+if [ "$DESIRED_OUTPUT_ZIP" != "$REAL_OUTPUT_ZIP" ]
+then
+    mv $REAL_OUTPUT_ZIP $DESIRED_OUTPUT_ZIP
+fi

--- a/bin/fastqc_wrapper.sh
+++ b/bin/fastqc_wrapper.sh
@@ -2,16 +2,11 @@
 #####################################################################################################################
 ### This is a wrapper for fastqc used in the snakefile.                                                           
 ###
-###     Usage: bin/fastqc_wrapper.sh {input} {params.output_dir} {output.html} 
-{output.zip} {log}                 ###
-###     Reason: Fastqc implicitly generates output files based on the input file name. 
-Therefore, if these are    ###
-###             not the same, this output is moved to the explicitly Snakefile defined 
-output location.           ###
-###     I had to put this simple bash code into a script because of the Snakemake-bash 
-strict settings, see:      ###
-### 
-https://snakemake.readthedocs.io/en/stable/project_info/faq.html#my-shell-command-fails-with-with-errors-about-an-unbound-variable-what-s-wrong
+###     Usage: bin/fastqc_wrapper.sh {input} {params.output_dir} {output.html} {output.zip} {log}                 ###
+###     Reason: Fastqc implicitly generates output files based on the input file name. Therefore, if these are    ###
+###             not the same, this output is moved to the explicitly Snakefile defined output location.           ###
+###     I had to put this simple bash code into a script because of the Snakemake-bash strict settings, see:      ###
+### https://snakemake.readthedocs.io/en/stable/project_info/faq.html#my-shell-command-fails-with-with-errors-about-an-unbound-variable-what-s-wrong
 #####################################################################################################################
 
 # Import the positional arguments (specified in the Snakefile)
@@ -21,8 +16,7 @@ DESIRED_OUTPUT_HTML="$3"
 DESIRED_OUTPUT_ZIP="$4"
 LOG="$5"
 
-# Generate sample basename (i.e. remove everything before the last '/' and then remove 
-everything after the '.')
+# Generate sample basename (i.e. remove everything before the last '/' and then remove everything after the '.')
 EXTENSION1=".gz"
 EXTENSION2=".fastq"
 EXTENSION3=".fq"
@@ -35,16 +29,14 @@ TEMP3=${TEMP2//$EXTENSION3/}
 
 SAMPLE_NAME="${TEMP3}"
 
-# These are the output files that fastqc implicitly generates (based on the input file 
-basename)
+# These are the output files that fastqc implicitly generates (based on the input file basename)
 REAL_OUTPUT_HTML="${OUTPUT_DIR}${SAMPLE_NAME}_fastqc.html"
 REAL_OUTPUT_ZIP="${OUTPUT_DIR}${SAMPLE_NAME}_fastqc.zip"
 
 # Run fastqc
 fastqc --outdir ${OUTPUT_DIR} ${INPUT_FILE} > ${LOG} 2>&1
 
-# If the implicit output file are not equal to the explicitly defined output in the 
-Snakefile, rename them to the explicitly defined output name.
+# If the implicit output file are not equal to the explicitly defined output in the Snakefile, rename them to the explicitly defined output name.
 if [ "$DESIRED_OUTPUT_HTML" != "$REAL_OUTPUT_HTML" ]
 then
     mv $REAL_OUTPUT_HTML $DESIRED_OUTPUT_HTML

--- a/bin/rules/clean_fastq.smk
+++ b/bin/rules/clean_fastq.smk
@@ -1,41 +1,43 @@
 rule clean_fastq:
-    input: 
-        lambda wildcards: (SAMPLES[wildcards.sample][i] for i in ['R1', 'R2'])
-    output: 
+    input:
+        lambda wildcards: (SAMPLES[wildcards.sample][i] for i in ["R1", "R2"]),
+    output:
         r1=OUT + "/clean_fastq/{sample}_pR1.fastq.gz",
         r2=OUT + "/clean_fastq/{sample}_pR2.fastq.gz",
-        unpaired = OUT + "/clean_fastq/{sample}_unpaired_joined.fastq.gz",
-        html = OUT + "/clean_fastq/{sample}_fastp.html",
-        json = OUT + "/clean_fastq/{sample}_fastp.json"
-    message: "Filtering low quality reads for {wildcards.sample}."
+        unpaired=OUT + "/clean_fastq/{sample}_unpaired_joined.fastq.gz",
+        html=OUT + "/clean_fastq/{sample}_fastp.html",
+        json=OUT + "/clean_fastq/{sample}_fastp.json",
+    message:
+        "Filtering low quality reads for {wildcards.sample}."
     conda:
         "../../envs/qc_and_clean.yaml"
     container:
         "docker://biocontainers/fastp:v0.20.1_cv1"
     threads: config["threads"]["trimmomatic"]
-    resources: mem_gb=config["mem_gb"]["trimmomatic"]
+    resources:
+        mem_gb=config["mem_gb"]["trimmomatic"],
     log:
-        OUT + "/log/clean_fastq/clean_fastq_{sample}.log"
+        OUT + "/log/clean_fastq/clean_fastq_{sample}.log",
     params:
-        mean_quality = config['mean_quality_threshold'],
-        window_size = config['window_size'],
-        min_length = config['min_read_length']
+        mean_quality=config["mean_quality_threshold"],
+        window_size=config["window_size"],
+        min_length=config["min_read_length"],
     shell:
         """
-fastp --in1 {input[0]} \
-    --in2 {input[1]} \
-    --out1 {output.r1} \
-    --out2 {output.r2} \
-    --unpaired1 {output.unpaired} \
-    --unpaired2 {output.unpaired} \
-    --html {output.html} \
-    --json {output.json} \
-    --report_title "FastP report for sample {wildcards.sample}" \
-    --detect_adapter_for_pe \
-    --thread {threads} \
-    --cut_right \
-    --cut_window_size {params.window_size} \
-    --cut_mean_quality {params.mean_quality} \
-    --correction \
-    --length_required {params.min_length} > {log} 2>&1
+        fastp --in1 {input[0]} \
+            --in2 {input[1]} \
+            --out1 {output.r1} \
+            --out2 {output.r2} \
+            --unpaired1 {output.unpaired} \
+            --unpaired2 {output.unpaired} \
+            --html {output.html} \
+            --json {output.json} \
+            --report_title "FastP report for sample {wildcards.sample}" \
+            --detect_adapter_for_pe \
+            --thread {threads} \
+            --cut_right \
+            --cut_window_size {params.window_size} \
+            --cut_mean_quality {params.mean_quality} \
+            --correction \
+            --length_required {params.min_length} > {log} 2>&1
         """

--- a/bin/rules/de_novo_assembly.smk
+++ b/bin/rules/de_novo_assembly.smk
@@ -2,20 +2,24 @@
 ##### De novo assembly                                                  #####
 #############################################################################
 
-expected_assembly_folders = [temp(directory(OUT + "/de_novo_assembly/{sample}/" + f"K{kmer_size}")) for kmer_size in config["kmer_size"].split(',')]
+expected_assembly_folders = [
+    temp(directory(OUT + "/de_novo_assembly/{sample}/" + f"K{kmer_size}"))
+    for kmer_size in config["kmer_size"].split(",")
+]
+
 
 rule de_novo_assembly:
     input:
-        r1 = OUT + "/clean_fastq/{sample}_pR1.fastq.gz",        
-        r2 = OUT + "/clean_fastq/{sample}_pR2.fastq.gz",
-        fastq_unpaired = OUT + "/clean_fastq/{sample}_unpaired_joined.fastq.gz"
+        r1=OUT + "/clean_fastq/{sample}_pR1.fastq.gz",
+        r2=OUT + "/clean_fastq/{sample}_pR2.fastq.gz",
+        fastq_unpaired=OUT + "/clean_fastq/{sample}_unpaired_joined.fastq.gz",
     output:
-        scaffolds = OUT + "/de_novo_assembly/{sample}/scaffolds.fasta",
-        contigs = temp(OUT + "/de_novo_assembly/{sample}/contigs.fasta"),
-        k21 = expected_assembly_folders,
-        misc = temp(directory(OUT + "/de_novo_assembly/{sample}/misc")),
-        tmp = temp(directory(OUT + "/de_novo_assembly/{sample}/tmp")),
-        state = temp(directory(OUT + "/de_novo_assembly/{sample}/pipeline_state")),
+        scaffolds=OUT + "/de_novo_assembly/{sample}/scaffolds.fasta",
+        contigs=temp(OUT + "/de_novo_assembly/{sample}/contigs.fasta"),
+        k21=expected_assembly_folders,
+        misc=temp(directory(OUT + "/de_novo_assembly/{sample}/misc")),
+        tmp=temp(directory(OUT + "/de_novo_assembly/{sample}/tmp")),
+        state=temp(directory(OUT + "/de_novo_assembly/{sample}/pipeline_state")),
         sh=temp(OUT + "/de_novo_assembly/{sample}/run_spades.sh"),
         yaml=temp(OUT + "/de_novo_assembly/{sample}/run_spades.yaml"),
         fastg=temp(OUT + "/de_novo_assembly/{sample}/assembly_graph.fastg"),
@@ -27,69 +31,73 @@ rule de_novo_assembly:
         params=temp(OUT + "/de_novo_assembly/{sample}/params.txt"),
         scaffpath=temp(OUT + "/de_novo_assembly/{sample}/scaffolds.paths"),
         splog=temp(OUT + "/de_novo_assembly/{sample}/spades.log"),
-        gfa_simplified=temp(OUT + "/de_novo_assembly/{sample}/assembly_graph_after_simplification.gfa")
-    message: "Making de novo assembly for {wildcards.sample}."
+        gfa_simplified=temp(
+            OUT + "/de_novo_assembly/{sample}/assembly_graph_after_simplification.gfa"
+        ),
+    message:
+        "Making de novo assembly for {wildcards.sample}."
     conda:
         "../../envs/spades.yaml"
     container:
         "docker://quay.io/biocontainers/spades:3.15.3--h95f258a_0"
-    threads: config["threads"]["spades"],
-    resources: mem_gb=config["mem_gb"]["spades"]
+    threads: config["threads"]["spades"]
+    resources:
+        mem_gb=config["mem_gb"]["spades"],
     params:
-        output_dir = OUT + "/de_novo_assembly/{sample}",
-        kmersizes = config["kmer_size"]
+        output_dir=OUT + "/de_novo_assembly/{sample}",
+        kmersizes=config["kmer_size"],
     log:
-        OUT + "/log/de_novo_assembly/{sample}_de_novo_assembly.log"
+        OUT + "/log/de_novo_assembly/{sample}_de_novo_assembly.log",
     shell:
         """
-unpaired_file_size=$(wc {input.fastq_unpaired} | awk '{{print $1}}')
+        unpaired_file_size=$(wc {input.fastq_unpaired} | awk '{{print $1}}')
 
-if [ ${{unpaired_file_size}} -gt 0 ];then
-    echo "Running spades without using unpaired reads to make scaffolds (there were no unpaired reads).\n" > {log}
-    spades.py --isolate \
-        -1 {input.r1} \
-        -2 {input.r2} \
-        -s {input.fastq_unpaired} \
-        -o {params.output_dir} \
-        -k {params.kmersizes} \
-        -m {resources.mem_gb} \
-        -t {threads} >> {log}
-else
-    echo "Running spades using unpaired reads to make scaffolds.\n" > {log}
-    spades.py --isolate \
-        -1 {input.r1} \
-        -2 {input.r2} \
-        -o {params.output_dir} \
-        -k {params.kmersizes} \
-        -m {resources.mem_gb} \
-        -t {threads} >> {log}
-fi
+        if [ ${{unpaired_file_size}} -gt 0 ];then
+            echo "Running spades without using unpaired reads to make scaffolds (there were no unpaired reads).\n" > {log}
+            spades.py --isolate \
+                -1 {input.r1} \
+                -2 {input.r2} \
+                -s {input.fastq_unpaired} \
+                -o {params.output_dir} \
+                -k {params.kmersizes} \
+                -m {resources.mem_gb} \
+                -t {threads} >> {log}
+        else
+            echo "Running spades using unpaired reads to make scaffolds.\n" > {log}
+            spades.py --isolate \
+                -1 {input.r1} \
+                -2 {input.r2} \
+                -o {params.output_dir} \
+                -k {params.kmersizes} \
+                -m {resources.mem_gb} \
+                -t {threads} >> {log}
+        fi
 
-if [ -f {output.scaffolds} ]; then
-    cp {output.contigs} {output.scaffolds}
-fi
+        if [ -f {output.scaffolds} ]; then
+            cp {output.contigs} {output.scaffolds}
+        fi
         """
-
-
 
 
 rule filter_de_novo_assembly:
     input:
-        OUT + "/de_novo_assembly/{sample}/scaffolds.fasta"
+        OUT + "/de_novo_assembly/{sample}/scaffolds.fasta",
     output:
-        OUT + "/de_novo_assembly_filtered/{sample}.fasta"
-    message: "Filtering out small contigs for the de novo assembly of {wildcards.sample}."
+        OUT + "/de_novo_assembly_filtered/{sample}.fasta",
+    message:
+        "Filtering out small contigs for the de novo assembly of {wildcards.sample}."
     conda:
         "../../envs/spades.yaml"
     container:
         "library://alesr13/default/seqtk_gawk:v1.3.1"
-    threads: config["threads"]["parsing"],
-    resources: mem_gb=config["mem_gb"]["parsing"]
+    threads: config["threads"]["parsing"]
+    resources:
+        mem_gb=config["mem_gb"]["parsing"],
     params:
-        minlen=config["contig_length_threshold"]
+        minlen=config["contig_length_threshold"],
     log:
-        OUT + "/log/de_novo_assembly/{sample}_filter_assembly.log"
+        OUT + "/log/de_novo_assembly/{sample}_filter_assembly.log",
     shell:
         """
-seqtk seq {input} 2>> {log} | gawk -F "_" '/^>/ {{if ($4 >= {params.minlen}) {{print $0; getline; print $0}};}}' 2>> {log} 1> {output} 
+        seqtk seq {input} 2>> {log} | gawk -F "_" '/^>/ {{if ($4 >= {params.minlen}) {{print $0; getline; print $0}};}}' 2>> {log} 1> {output} 
         """

--- a/bin/rules/fastqc_clean_data.smk
+++ b/bin/rules/fastqc_clean_data.smk
@@ -2,29 +2,32 @@
 ##### Data quality control and cleaning                                 #####
 #############################################################################
 
+
 rule qc_clean_fastq:
     input:
-        OUT + "/clean_fastq/{sample}_p{read}.fastq.gz"
+        OUT + "/clean_fastq/{sample}_p{read}.fastq.gz",
     output:
-        html = OUT + "/qc_clean_fastq/{sample}_p{read}_fastqc.html",
-        zip = OUT + "/qc_clean_fastq/{sample}_p{read}_fastqc.zip"
-    message: "Running FastQC after filtering/trimming {wildcards.sample}."
+        html=OUT + "/qc_clean_fastq/{sample}_p{read}_fastqc.html",
+        zip=OUT + "/qc_clean_fastq/{sample}_p{read}_fastqc.zip",
+    message:
+        "Running FastQC after filtering/trimming {wildcards.sample}."
     conda:
         "../../envs/qc_and_clean.yaml"
     container:
         "docker://biocontainers/fastqc:v0.11.9_cv8"
     threads: config["threads"]["fastqc"]
-    resources: mem_gb=config["mem_gb"]["fastqc"]
+    resources:
+        mem_gb=config["mem_gb"]["fastqc"],
     log:
-        OUT + "/log/qc_clean_fastq/qc_clean_fastq_{sample}_{read}.log"
+        OUT + "/log/qc_clean_fastq/qc_clean_fastq_{sample}_{read}.log",
     params:
-        output_dir = OUT + "/qc_clean_fastq/"
+        output_dir=OUT + "/qc_clean_fastq/",
     shell:
         """
-if [ -s {input} ]
-then
-    fastqc --quiet --outdir {params.output_dir} {input} >> {log} 
-else  
-    touch {output}
-fi
-    """
+        if [ -s {input} ]
+        then
+            fastqc --quiet --outdir {params.output_dir} {input} >> {log} 
+        else  
+            touch {output}
+        fi
+        """

--- a/bin/rules/fastqc_raw_data.smk
+++ b/bin/rules/fastqc_raw_data.smk
@@ -18,10 +18,10 @@ rule qc_raw_fastq:
     resources:
         mem_gb=config["mem_gb"]["fastqc"],
     params:
-        output_dir=OUT + "/qc_raw_fastq",
+        output_dir=OUT + "/qc_raw_fastq/",
     log:
         OUT + "/log/qc_raw_fastq/qc_raw_fastq_{sample}_{read}.log",
     shell:
         """
-        bash bin/fastqc_wrapper.sh {input} {params.output_dir} {output.html} {output.zip} {log}
+        bash bin/fastqc_wrapper.sh {input} {params.output_dir} {output.html} {output.zip} {log} > {log} 2>&1
         """

--- a/bin/rules/fastqc_raw_data.smk
+++ b/bin/rules/fastqc_raw_data.smk
@@ -21,7 +21,7 @@ rule qc_raw_fastq:
         output_dir = OUT + "/qc_raw_fastq"
     shell:
         """
-fastqc --quiet --outdir {params.output_dir} {input} &> {log} 
+fastqc --outdir {params.output_dir} {input} &> {log}
 
 if [ ! -f {output.html} ]
 then

--- a/bin/rules/fastqc_raw_data.smk
+++ b/bin/rules/fastqc_raw_data.smk
@@ -8,7 +8,7 @@ rule qc_raw_fastq:
     output:
         html = OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.html",
         zip = OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.zip"
-    shadow: "minimal"
+    shadow: "full"
     message: "Running FastQC in the raw data for {wildcards.sample}."
     conda:
         "../../envs/qc_and_clean.yaml"

--- a/bin/rules/fastqc_raw_data.smk
+++ b/bin/rules/fastqc_raw_data.smk
@@ -8,6 +8,7 @@ rule qc_raw_fastq:
     output:
         html = OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.html",
         zip = OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.zip"
+    shadow: "minimal"
     message: "Running FastQC in the raw data for {wildcards.sample}."
     conda:
         "../../envs/qc_and_clean.yaml"

--- a/bin/rules/fastqc_raw_data.smk
+++ b/bin/rules/fastqc_raw_data.smk
@@ -2,35 +2,26 @@
 ##### Data quality control and cleaning                                 #####
 #############################################################################
 
+
 rule qc_raw_fastq:
     input:
         lambda wildcards: SAMPLES[wildcards.sample][wildcards.read],
     output:
         html = OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.html",
         zip = OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.zip"
-    shadow: "full"
     message: "Running FastQC in the raw data for {wildcards.sample}."
     conda:
         "../../envs/qc_and_clean.yaml"
     container:
         "docker://biocontainers/fastqc:v0.11.9_cv8"
     threads: config["threads"]["fastqc"]
-    resources: mem_gb=config["mem_gb"]["fastqc"]
-    log:
-        OUT + "/log/qc_raw_fastq/qc_raw_fastq_{sample}_{read}.log"
+    resources:
+        mem_gb=config["mem_gb"]["fastqc"],
     params:
-        output_dir = OUT + "/qc_raw_fastq"
+        output_dir=OUT + "/qc_raw_fastq",
+    log:
+        OUT + "/log/qc_raw_fastq/qc_raw_fastq_{sample}_{read}.log",
     shell:
         """
-fastqc --outdir {params.output_dir} {input} &> {log}
-
-if [ ! -f {output.html} ]
-then
-    find {params.output_dir} -type f -name {wildcards.sample}*{wildcards.read}*.html -exec mv {{}} {output.html} \;
-fi
-
-if [ ! -f {output.zip} ]
-then
-    find {params.output_dir} -type f -name {wildcards.sample}*{wildcards.read}*.zip -exec mv {{}} {output.zip} \;
-fi
+        bash bin/fastqc_wrapper.sh {input} {params.output_dir} {output.html} {output.zip} {log}
         """

--- a/bin/rules/generate_contig_metrics.smk
+++ b/bin/rules/generate_contig_metrics.smk
@@ -2,30 +2,34 @@
 ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
 #############################################################################
 
+
 rule pileup_contig_metrics:
     input:
-        bam = OUT + "/qc_de_novo_assembly/insert_size/{sample}_sorted.bam",
-        fasta = OUT + "/de_novo_assembly_filtered/{sample}.fasta"
+        bam=OUT + "/qc_de_novo_assembly/insert_size/{sample}_sorted.bam",
+        fasta=OUT + "/de_novo_assembly_filtered/{sample}.fasta",
     output:
-        summary = OUT + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_MinLenFiltSummary.tsv",
-        perScaffold = OUT + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_perMinLenFiltScaffold.tsv",
-    message: "Making pileup and calculating contig metrics for {wildcards.sample}."
+        summary=OUT
+        + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_MinLenFiltSummary.tsv",
+        perScaffold=OUT
+        + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_perMinLenFiltScaffold.tsv",
+    message:
+        "Making pileup and calculating contig metrics for {wildcards.sample}."
     conda:
         "../../envs/scaffold_analyses.yaml"
     container:
         "docker://staphb/bbtools:38.86"
     log:
-        OUT + "/log/qc_de_novo_assembly/pileup_contig_metrics_{sample}.log"
+        OUT + "/log/qc_de_novo_assembly/pileup_contig_metrics_{sample}.log",
     threads: config["threads"]["pileup"]
-    resources: mem_gb=config["mem_gb"]["pileup"]
+    resources:
+        mem_gb=config["mem_gb"]["pileup"],
     shell:
         """
-pileup.sh in={input.bam} \
-    ref={input.fasta} \
-    out={output.perScaffold} \
-    secondary=f \
-    samstreamer=t 2> {output.summary} 
-    
-cp {output.summary} {log}
-        """
+        pileup.sh in={input.bam} \
+            ref={input.fasta} \
+            out={output.perScaffold} \
+            secondary=f \
+            samstreamer=t 2> {output.summary} 
 
+        cp {output.summary} {log}
+        """

--- a/bin/rules/identify_species.smk
+++ b/bin/rules/identify_species.smk
@@ -1,56 +1,60 @@
 rule identify_species:
-    input: 
-        OUT + "/de_novo_assembly_filtered/{sample}.fasta"
+    input:
+        OUT + "/de_novo_assembly_filtered/{sample}.fasta",
     output:
-        kraken2_kreport = temp(OUT + '/identify_species/{sample}/{sample}.kreport2'),
-        bracken_s = OUT + '/identify_species/{sample}/{sample}_species_content.txt',
-        bracken_kreport = OUT + '/identify_species/{sample}/{sample}_bracken_species.kreport2'
-    message: "Running species identification for {wildcards.sample}."
+        kraken2_kreport=temp(OUT + "/identify_species/{sample}/{sample}.kreport2"),
+        bracken_s=OUT + "/identify_species/{sample}/{sample}_species_content.txt",
+        bracken_kreport=OUT
+        + "/identify_species/{sample}/{sample}_bracken_species.kreport2",
+    message:
+        "Running species identification for {wildcards.sample}."
     log:
-        OUT + '/log/identify_species/{sample}.log'
-    threads: 
-        config["threads"]["kraken2"]
+        OUT + "/log/identify_species/{sample}.log",
+    threads: config["threads"]["kraken2"]
     conda:
-        '../../envs/identify_species.yaml'
+        "../../envs/identify_species.yaml"
     container:
-        'library://alesr13/default/kraken2_bracken:v2.1.2_v2.6.1'
+        "library://alesr13/default/kraken2_bracken:v2.1.2_v2.6.1"
     params:
-        kraken_db=config["db_dir"]
+        kraken_db=config["db_dir"],
     resources:
-        mem_gb=config["mem_gb"]["kraken2"]
+        mem_gb=config["mem_gb"]["kraken2"],
     shell:
         """
-# Adding --confidence 0.05 causes 0 kmers assigned to species in some samples
-# That breaks bracken
-kraken2 --db {params.kraken_db} \
-    --threads {threads} \
-    --report {output.kraken2_kreport} \
-    {input}  &> {log} 
+        # Adding --confidence 0.05 causes 0 kmers assigned to species in some samples
+        # That breaks bracken
+        kraken2 --db {params.kraken_db} \
+            --threads {threads} \
+            --report {output.kraken2_kreport} \
+            {input}  &> {log} 
 
-bracken -d {params.kraken_db} \
-    -i {output.kraken2_kreport} \
-    -o {output.bracken_s} \
-    -r 150 \
-    -l S \
-    -t 0  &>> {log} 
+        bracken -d {params.kraken_db} \
+            -i {output.kraken2_kreport} \
+            -o {output.bracken_s} \
+            -r 150 \
+            -l S \
+            -t 0  &>> {log} 
 
         """
 
 
 rule top_species_multireport:
-    input: 
-        expand(OUT + '/identify_species/{sample}/{sample}_species_content.txt', sample = SAMPLES)
+    input:
+        expand(
+            OUT + "/identify_species/{sample}/{sample}_species_content.txt",
+            sample=SAMPLES,
+        ),
     output:
-        OUT + '/identify_species/top1_species_multireport.csv'
-    message: "Generating multireport for spcies identification."
+        OUT + "/identify_species/top1_species_multireport.csv",
+    message:
+        "Generating multireport for spcies identification."
     log:
-        OUT + '/log/identify_species/multireport.log'
-    threads: 
-        config["threads"]["parsing"]
+        OUT + "/log/identify_species/multireport.log",
+    threads: config["threads"]["parsing"]
     resources:
-        mem_gb=config["mem_gb"]["parsing"]
+        mem_gb=config["mem_gb"]["parsing"],
     shell:
         """
-python bin/make_summary_main_species.py --input-files {input} \
-                                        --output-multireport {output} > {log}
+        python bin/make_summary_main_species.py --input-files {input} \
+                                                --output-multireport {output} > {log}
         """

--- a/bin/rules/multiqc.smk
+++ b/bin/rules/multiqc.smk
@@ -2,33 +2,50 @@
 ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
 #############################################################################
 
+
 rule multiqc:
     input:
-        expand(OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.zip", sample = SAMPLES, read = "R1 R2".split()),
-        expand(OUT + "/qc_clean_fastq/{sample}_p{read}_fastqc.zip", sample = SAMPLES, read = "R1 R2".split()),
-        expand(OUT + "/clean_fastq/{sample}_fastp.json", sample = SAMPLES),
+        expand(
+            OUT + "/qc_raw_fastq/{sample}_{read}_fastqc.zip",
+            sample=SAMPLES,
+            read="R1 R2".split(),
+        ),
+        expand(
+            OUT + "/qc_clean_fastq/{sample}_p{read}_fastqc.zip",
+            sample=SAMPLES,
+            read="R1 R2".split(),
+        ),
+        expand(OUT + "/clean_fastq/{sample}_fastp.json", sample=SAMPLES),
         OUT + "/qc_de_novo_assembly/quast/report.tsv",
         OUT + "/qc_de_novo_assembly/checkm/checkm_report.tsv",
-        expand(OUT + "/log/clean_fastq/clean_fastq_{sample}.log", sample = SAMPLES),
-        expand(OUT + "/qc_de_novo_assembly/insert_size/{sample}_insert_size_metrics.txt", sample = SAMPLES),
-        expand(OUT + '/identify_species/{sample}/{sample}_bracken_species.kreport2', sample = SAMPLES)
+        expand(OUT + "/log/clean_fastq/clean_fastq_{sample}.log", sample=SAMPLES),
+        expand(
+            OUT + "/qc_de_novo_assembly/insert_size/{sample}_insert_size_metrics.txt",
+            sample=SAMPLES,
+        ),
+        expand(
+            OUT + "/identify_species/{sample}/{sample}_bracken_species.kreport2",
+            sample=SAMPLES,
+        ),
     output:
         OUT + "/multiqc/multiqc.html",
-    message: "Making MultiQC report."
+    message:
+        "Making MultiQC report."
     conda:
         "../../envs/multiqc.yaml"
     container:
         "docker://quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0"
     threads: config["threads"]["multiqc"]
-    resources: mem_gb=config["mem_gb"]["multiqc"]
+    resources:
+        mem_gb=config["mem_gb"]["multiqc"],
     params:
         config_file="files/multiqc_config.yaml",
-        output_dir=OUT + "/multiqc"
+        output_dir=OUT + "/multiqc",
     log:
-        OUT + "/log/multiqc/multiqc.log"
+        OUT + "/log/multiqc/multiqc.log",
     shell:
         """
-multiqc --force --config {params.config_file} \
-    -o {params.output_dir} \
-    -n multiqc.html {input} &> {log}
-    """
+        multiqc --force --config {params.config_file} \
+            -o {params.output_dir} \
+            -n multiqc.html {input} &> {log}
+        """

--- a/bin/rules/parse_bbtools.smk
+++ b/bin/rules/parse_bbtools.smk
@@ -2,16 +2,22 @@
 ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
 #############################################################################
 
+
 rule parse_bbtools:
     input:
-        expand(OUT + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_perMinLenFiltScaffold.tsv", sample=SAMPLES),
+        expand(
+            OUT
+            + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_perMinLenFiltScaffold.tsv",
+            sample=SAMPLES,
+        ),
     output:
         OUT + "/qc_de_novo_assembly/bbtools_scaffolds/bbtools_scaffolds.tsv",
-    message: "Parsing the results of bbtools (pileup contig metrics)."
+    message:
+        "Parsing the results of bbtools (pileup contig metrics)."
     threads: config["threads"]["parsing"]
-    resources: mem_gb=config["mem_gb"]["parsing"]
+    resources:
+        mem_gb=config["mem_gb"]["parsing"],
     log:
-        OUT + "/log/qc_de_novo_assembly/pileup_contig_metrics_combined.log"
+        OUT + "/log/qc_de_novo_assembly/pileup_contig_metrics_combined.log",
     script:
         "../parse_bbtools.py"
-

--- a/bin/rules/parse_bbtools_summary.smk
+++ b/bin/rules/parse_bbtools_summary.smk
@@ -2,15 +2,22 @@
 ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
 #############################################################################
 
+
 rule parse_bbtools_summary:
     input:
-        expand(OUT + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_MinLenFiltSummary.tsv", sample=SAMPLES)
+        expand(
+            OUT
+            + "/qc_de_novo_assembly/bbtools_scaffolds/per_sample/{sample}_MinLenFiltSummary.tsv",
+            sample=SAMPLES,
+        ),
     output:
-        OUT + "/qc_de_novo_assembly/bbtools_scaffolds/bbtools_summary_report.tsv"
-    message: "Parsing the results of bbtools (pileup contig metrics) and making a multireport."
+        OUT + "/qc_de_novo_assembly/bbtools_scaffolds/bbtools_summary_report.tsv",
+    message:
+        "Parsing the results of bbtools (pileup contig metrics) and making a multireport."
     threads: config["threads"]["parsing"]
-    resources: mem_gb=config["mem_gb"]["parsing"]
+    resources:
+        mem_gb=config["mem_gb"]["parsing"],
     log:
-        OUT + "/log/qc_de_novo_assembly/pileup_contig_metrics_combined.log"
+        OUT + "/log/qc_de_novo_assembly/pileup_contig_metrics_combined.log",
     shell:
         "python bin/parse_bbtools_summary.py -i {input} -o {output} > {log}"

--- a/bin/rules/parse_checkm.smk
+++ b/bin/rules/parse_checkm.smk
@@ -2,16 +2,22 @@
 ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
 #############################################################################
 
+
 rule parse_checkm:
     input:
-        expand(OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}/checkm_{sample}.tsv", sample=SAMPLES)
+        expand(
+            OUT
+            + "/qc_de_novo_assembly/checkm/per_sample/{sample}/checkm_{sample}.tsv",
+            sample=SAMPLES,
+        ),
     output:
-        OUT + "/qc_de_novo_assembly/checkm/checkm_report.tsv"
-    message: "Parsing the results of CheckM and making a multireport."
+        OUT + "/qc_de_novo_assembly/checkm/checkm_report.tsv",
+    message:
+        "Parsing the results of CheckM and making a multireport."
     threads: config["threads"]["parsing"]
-    resources: mem_gb=config["mem_gb"]["parsing"]
+    resources:
+        mem_gb=config["mem_gb"]["parsing"],
     log:
-        OUT + "/log/checkm/checkm_combined.log"
+        OUT + "/log/checkm/checkm_combined.log",
     script:
         "../parse_checkM.py"
-

--- a/bin/rules/picard_insert_size.smk
+++ b/bin/rules/picard_insert_size.smk
@@ -2,50 +2,63 @@
 ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
 #############################################################################
 
+
 rule picard_insert_size:
     input:
         fasta=OUT + "/de_novo_assembly_filtered/{sample}.fasta",
         pR1=OUT + "/clean_fastq/{sample}_pR1.fastq.gz",
-        pR2=OUT + "/clean_fastq/{sample}_pR2.fastq.gz"
+        pR2=OUT + "/clean_fastq/{sample}_pR2.fastq.gz",
     output:
-        temp(multiext(OUT + "/de_novo_assembly_filtered/{sample}.fasta", ".ann", ".amb", ".bwt.2bit.64", ".pac", ".0123")),
+        temp(
+            multiext(
+                OUT + "/de_novo_assembly_filtered/{sample}.fasta",
+                ".ann",
+                ".amb",
+                ".bwt.2bit.64",
+                ".pac",
+                ".0123",
+            )
+        ),
         bam=temp(OUT + "/qc_de_novo_assembly/insert_size/{sample}_sorted.bam"),
         bam_bai=temp(OUT + "/qc_de_novo_assembly/insert_size/{sample}_sorted.bam.bai"),
         txt=OUT + "/qc_de_novo_assembly/insert_size/{sample}_insert_size_metrics.txt",
-        pdf=OUT + "/qc_de_novo_assembly/insert_size/{sample}_insert_size_histogram.pdf"
-    message: "Calculating insert size for {wildcards.sample}."
+        pdf=OUT + "/qc_de_novo_assembly/insert_size/{sample}_insert_size_histogram.pdf",
+    message:
+        "Calculating insert size for {wildcards.sample}."
     conda:
         "../../envs/scaffold_analyses.yaml"
     container:
         "library://alesr13/default/samtools_bwa_picard:v0.1"
     log:
-        OUT + "/log/qc_de_novo_assembly/picard_insert_size/picard_insert_size_{sample}.log"
-    threads: config["threads"]["picard"],
-    resources: mem_gb=config["mem_gb"]["picard"]
+        OUT
+        + "/log/qc_de_novo_assembly/picard_insert_size/picard_insert_size_{sample}.log",
+    threads: config["threads"]["picard"]
+    resources:
+        mem_gb=config["mem_gb"]["picard"],
     params:
-        run_in_container = config['run_in_container']
+        run_in_container=config["run_in_container"],
     shell:
         """
-set -euo pipefail
-bwa-mem2 index {input.fasta} > {log} 2>&1
+        set -euo pipefail
+        bwa-mem2 index {input.fasta} > {log} 2>&1
 
-bwa-mem2 mem -t {threads} {input.fasta} \
-{input.pR1} \
-{input.pR2} 2>> {log} |\
-samtools view -@ {threads} -uS - 2>> {log} |\
-samtools sort -@ {threads} - -o {output.bam} >> {log} 2>&1
+        bwa-mem2 mem -t {threads} {input.fasta} \
+        {input.pR1} \
+        {input.pR2} 2>> {log} |\
+        samtools view -@ {threads} -uS - 2>> {log} |\
+        samtools sort -@ {threads} - -o {output.bam} >> {log} 2>&1
 
-samtools index -@ {threads} {output.bam} >> {log} 2>&1
+        samtools index -@ {threads} {output.bam} >> {log} 2>&1
 
-if [ {params.run_in_container} == True ]; then
-    picard-tools CollectInsertSizeMetrics \
-    I={output.bam} \
-    O={output.txt} \
-    H={output.pdf} >> {log} 2>&1
-else
-    picard -Dpicard.useLegacyParser=false CollectInsertSizeMetrics \
-    -I {output.bam} \
-    -O {output.txt} \
-    -H {output.pdf} >> {log} 2>&1
-fi
+        if [ {params.run_in_container} == True ]; then
+            picard-tools CollectInsertSizeMetrics \
+            I={output.bam} \
+            O={output.txt} \
+            H={output.pdf} >> {log} 2>&1
+        else
+            picard -Dpicard.useLegacyParser=false CollectInsertSizeMetrics \
+            -I {output.bam} \
+            -O {output.txt} \
+            -H {output.pdf} >> {log} 2>&1
+        fi
         """

--- a/bin/rules/run_checkm.smk
+++ b/bin/rules/run_checkm.smk
@@ -2,48 +2,57 @@
 ##### Scaffold analyses: QUAST, CheckM, picard, bbmap and QC-metrics    #####
 #############################################################################
 
+
 rule checkm:
     input:
-        assembly = OUT + "/de_novo_assembly/{sample}/scaffolds.fasta",
-        genus_bracken = OUT + '/identify_species/{sample}/{sample}_bracken_species.kreport2'
+        assembly=OUT + "/de_novo_assembly/{sample}/scaffolds.fasta",
+        genus_bracken=OUT
+        + "/identify_species/{sample}/{sample}_bracken_species.kreport2",
     output:
-        result = OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}/checkm_{sample}.tsv",
-        tmp_dir1 = temp(directory(OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}/bins")),
-        tmp_dir2 = temp(directory(OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}/storage"))
-    message: "Running CheckM for {wildcards.sample}."
+        result=OUT
+        + "/qc_de_novo_assembly/checkm/per_sample/{sample}/checkm_{sample}.tsv",
+        tmp_dir1=temp(
+            directory(OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}/bins")
+        ),
+        tmp_dir2=temp(
+            directory(OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}/storage")
+        ),
+    message:
+        "Running CheckM for {wildcards.sample}."
     conda:
         "../../envs/checkm.yaml"
     container:
         "docker://quay.io/biocontainers/checkm-genome:1.1.3--py_1"
-    threads: config["threads"]["checkm"],
-    resources: mem_gb=config["mem_gb"]["checkm"]
+    threads: config["threads"]["checkm"]
+    resources:
+        mem_gb=config["mem_gb"]["checkm"],
     params:
         input_dir=OUT + "/de_novo_assembly/{sample}/",
         output_dir=OUT + "/qc_de_novo_assembly/checkm/per_sample/{sample}",
-        genus = lambda wildcards: SAMPLES[wildcards.sample]['genus']
+        genus=lambda wildcards: SAMPLES[wildcards.sample]["genus"],
     log:
-        OUT + "/log/qc_de_novo_assembly/checkm_{sample}.log"
+        OUT + "/log/qc_de_novo_assembly/checkm_{sample}.log",
     shell:
         """
-if [ "{params.genus}" == "None" ];then
-    # Get top (first appearing) species from the bracken.kreport
-    genus=$(grep "\sG\s" {input.genus_bracken} | head -n 1 | cut -f6 | xargs)
-    genus_capitalized=${{genus^}}
-    checkm taxonomy_wf genus "${{genus_capitalized}}" \
-        {params.input_dir} \
-        {params.output_dir} \
-        -t {threads} \
-        -x scaffolds.fasta > {output.result}
-    mv {params.output_dir}/checkm.log {log}
-    echo "\nNOTE: No genus was provided and therefore the top 1 genus (${{genus}}) detected by Kraken2 + Bracken was used for reference." >> {log}
-else
-    genus_capitalized={params.genus}
-    genus_capitalized=${{genus_capitalized^}}
-    checkm taxonomy_wf genus "${{genus_capitalized}}" \
-        {params.input_dir} \
-        {params.output_dir} \
-        -t {threads} \
-        -x scaffolds.fasta > {output.result}
-    mv {params.output_dir}/checkm.log {log}
-fi
+        if [ "{params.genus}" == "None" ];then
+            # Get top (first appearing) species from the bracken.kreport
+            genus=$(grep "\sG\s" {input.genus_bracken} | head -n 1 | cut -f6 | xargs)
+            genus_capitalized=${{genus^}}
+            checkm taxonomy_wf genus "${{genus_capitalized}}" \
+                {params.input_dir} \
+                {params.output_dir} \
+                -t {threads} \
+                -x scaffolds.fasta > {output.result}
+            mv {params.output_dir}/checkm.log {log}
+            echo "\nNOTE: No genus was provided and therefore the top 1 genus (${{genus}}) detected by Kraken2 + Bracken was used for reference." >> {log}
+        else
+            genus_capitalized={params.genus}
+            genus_capitalized=${{genus_capitalized^}}
+            checkm taxonomy_wf genus "${{genus_capitalized}}" \
+                {params.input_dir} \
+                {params.output_dir} \
+                -t {threads} \
+                -x scaffolds.fasta > {output.result}
+            mv {params.output_dir}/checkm.log {log}
+        fi
         """

--- a/bin/rules/run_quast.smk
+++ b/bin/rules/run_quast.smk
@@ -5,21 +5,23 @@
 
 rule run_quast_combined:
     input:
-        expand(OUT + "/de_novo_assembly_filtered/{sample}.fasta", sample=SAMPLES)
+        expand(OUT + "/de_novo_assembly_filtered/{sample}.fasta", sample=SAMPLES),
     output:
-        OUT + "/qc_de_novo_assembly/quast/report.tsv"
-    message: "Running QUAST in all samples and creating multireport."
+        OUT + "/qc_de_novo_assembly/quast/report.tsv",
+    message:
+        "Running QUAST in all samples and creating multireport."
     conda:
         "../../envs/quast.yaml"
     container:
         "docker://staphb/quast:5.0.2"
-    threads: config["threads"]["quast"],
-    resources: mem_gb=config["mem_gb"]["quast"]
+    threads: config["threads"]["quast"]
+    resources:
+        mem_gb=config["mem_gb"]["quast"],
     params:
-        output_dir = OUT + "/qc_de_novo_assembly/quast"
+        output_dir=OUT + "/qc_de_novo_assembly/quast",
     log:
-        OUT + "/log/qc_de_novo_assembly/quast.log"
+        OUT + "/log/qc_de_novo_assembly/quast.log",
     shell:
         """
-quast.py --threads {threads} {input} --output-dir {params.output_dir} > {log}
+        quast.py --threads {threads} {input} --output-dir {params.output_dir} > {log}
         """

--- a/envs/condaenv.eckweqtp.requirements.txt
+++ b/envs/condaenv.eckweqtp.requirements.txt
@@ -1,0 +1,2 @@
+numpy
+--editable=git+https://github.com/RIVM-bioinformatics/base_juno_pipeline.git@v0.2.9#egg=base_juno


### PR DESCRIPTION
This solves a bug with the renaming of fastqc exports. The bug occured when sample ID's where prefixes of each other. e.g.
1_R1.fastq and 1a_R1.fastq.